### PR TITLE
[DP-272] Use correct url in login redirect

### DIFF
--- a/src/components/app/LoginRedirect.jsx
+++ b/src/components/app/LoginRedirect.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
-import { useParams } from 'react-router-dom';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { getProxyLoginUrl } from '@edx/frontend-enterprise-logistration';
+import { getLoginUrl } from '../utils/urls';
 
 /**
  * This wrapper component redirects the user to the enterprise proxy login view with additional query
@@ -22,11 +21,7 @@ export default function LoginRedirect({
     return children;
   }
 
-  const {
-    enterpriseCustomerInviteKey,
-  } = useParams();
-  const enterpriseSlug = window.location.host.split('.')[0];
-  global.location.href = getProxyLoginUrl(enterpriseSlug, enterpriseCustomerInviteKey);
+  global.location.href = getLoginUrl();
   return LoadingDisplay;
 }
 LoginRedirect.propTypes = {

--- a/src/components/app/LoginRedirect.jsx
+++ b/src/components/app/LoginRedirect.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getLoginUrl } from '../utils/urls';
 
@@ -21,7 +22,11 @@ export default function LoginRedirect({
     return children;
   }
 
-  global.location.href = getLoginUrl();
+  const {
+    enterpriseCustomerInviteKey,
+  } = useParams();
+  const enterpriseSlug = window.location.host.split('.')[0];
+  global.location.href = getLoginUrl(enterpriseSlug, enterpriseCustomerInviteKey);
   return LoadingDisplay;
 }
 LoginRedirect.propTypes = {

--- a/src/components/utils/urls.js
+++ b/src/components/utils/urls.js
@@ -1,0 +1,9 @@
+import { getConfig } from '@edx/frontend-platform/config';
+
+/**
+ * Returns a URL to the enterprise proxy login page in the LMS. The proxy-login page
+ * appropriately redirects enterprise users to the enterprise-specific logistration flow.
+ *
+ * @returns URL of the enterprise proxy login page in the LMS.
+ */
+export const getLoginUrl = () => `${getConfig().LMS_BASE_URL}/iam/login`;

--- a/src/components/utils/urls.js
+++ b/src/components/utils/urls.js
@@ -11,7 +11,7 @@ import { getConfig } from '@edx/frontend-platform/config';
 // eslint-disable-next-line import/prefer-default-export
 export const getLoginUrl = (enterpriseSlug, enterpriseCustomerInviteKey) => {
   const loginUrl = new URL(`${getConfig().LMS_BASE_URL}/iam/login/`);
-  const queryParams = new URLSearchParams();
+  const queryParams = loginUrl.searchParams;
 
   queryParams.append('next', global.location);
 

--- a/src/components/utils/urls.js
+++ b/src/components/utils/urls.js
@@ -1,9 +1,32 @@
 import { getConfig } from '@edx/frontend-platform/config';
 
 /**
- * Returns a URL to the enterprise proxy login page in the LMS. The proxy-login page
- * appropriately redirects enterprise users to the enterprise-specific logistration flow.
+ * Given either an `enterpriseSlug` or an `enterpriseCustomerInviteKey`, returns a
+ * URL to the dojo-auth-mfe. This is enterprise specific and aware
  *
+ * @param {string} enterpriseSlug Slug of an enterprise customer
+ * @param {string} enterpriseCustomerInviteKey UUID of an EnterpriseCustomerInviteKey
  * @returns URL of the enterprise proxy login page in the LMS.
  */
-export const getLoginUrl = () => `${getConfig().LMS_BASE_URL}/iam/login`;
+// eslint-disable-next-line import/prefer-default-export
+export const getLoginUrl = (enterpriseSlug, enterpriseCustomerInviteKey) => {
+  const loginUrl = new URL(`${getConfig().LMS_BASE_URL}/iam/login/`);
+  const queryParams = new URLSearchParams();
+
+  queryParams.append('next', global.location);
+
+  if (enterpriseSlug) {
+    queryParams.append('enterprise_slug', enterpriseSlug);
+
+    // append enterpriseSlug as a subdomain if it is not already there
+    if (loginUrl.hostname.split('.')[0] !== enterpriseSlug) {
+      loginUrl.hostname = `${enterpriseSlug}.${loginUrl.hostname}`;
+    }
+  }
+
+  if (enterpriseCustomerInviteKey) {
+    queryParams.append('enterprise_customer_invite_key', enterpriseCustomerInviteKey);
+  }
+
+  return loginUrl.href;
+};


### PR DESCRIPTION
- replace `getLoginProxyUrl` call for custom `getLoginUrl` that uses
  `/iam/login` redirect path

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
