### PR TITLE
[DCS-115] Add the languageCodeToLabel helper and show proper language n…

### DIFF
--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -129,7 +129,7 @@ export default function Dashboard() {
               />
             )
             : (
-              <Row>
+              <Row data-testid="learningPath">
                 {courses?.map((course) => (
                   <Col xs={12} md={6} lg={4} key={course.id} className="mb-4">
                     <CourseCard
@@ -151,7 +151,7 @@ export default function Dashboard() {
         >
           <hr />
           <Row>
-            <Col lg={8}>
+            <Col lg={8} data-testid="courseCatalog">
               <ActiveFilter filter={filter} />
               {catalogCoursesOnActivePage.length === 0 && (
                 <EmptyState

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -24,6 +24,8 @@ import {
   World,
 } from './data/svg';
 
+import { languageCodeToLabel } from '../../utils/common';
+
 function EmptyState({ title, text, image = emptyStateImage }) {
   return (
     <div className="dashboard-empty-state">
@@ -134,7 +136,7 @@ export default function Dashboard() {
                       active={activeCourse?.id === course.id}
                       title={course.title}
                       hours={course.hours_required}
-                      languages={[course.primary_language]}
+                      languages={[course.primary_language].map(languageCodeToLabel)}
                       skills={[course.difficulty_level]}
                       bgKey={course.id % 10}
                       onClick={() => setActiveCourse(course)}
@@ -167,7 +169,7 @@ export default function Dashboard() {
                           key={course.id}
                           title={course.title}
                           hours={course.hours_required}
-                          languages={[course.primary_language]}
+                          languages={[course.primary_language].map(languageCodeToLabel)}
                           skills={[course.difficulty_level]}
                           bgKey={course.id % 10}
                           onClick={() => setActiveCourse(course)}
@@ -218,7 +220,7 @@ export default function Dashboard() {
                 },
                 {
                   key: 'Primary language',
-                  value: activeCourse.primary_language,
+                  value: languageCodeToLabel(activeCourse.primary_language),
                   icon: <World />,
                 },
                 {

--- a/src/components/dashboard/tests/Dashboard.test.jsx
+++ b/src/components/dashboard/tests/Dashboard.test.jsx
@@ -229,7 +229,7 @@ describe('<Dashboard />', () => {
             },
             {
               title: 'Large numbers in Python',
-              primaryLanguage: 'en',
+              primary_language: 'en',
               hours_required: 13,
             },
           ],

--- a/src/components/dashboard/tests/Dashboard.test.jsx
+++ b/src/components/dashboard/tests/Dashboard.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { CourseContextProvider } from '../../course/CourseContextProvider';
@@ -195,7 +195,7 @@ describe('<Dashboard />', () => {
     expect(screen.getByText('1 course'));
   });
 
-  it('shows course card on learning path with 1 course', () => {
+  it('shows course card on learning path with 1 course', async () => {
     const userSubsidyState = {
       learningPathData: {
         ...defaultLearningPathData,
@@ -209,9 +209,10 @@ describe('<Dashboard />', () => {
       catalog: defaultCatalog,
     };
     renderWithRouter(<DashboardWithContext initialUserSubsidyState={userSubsidyState} />);
-    expect(screen.getByText('How to train your dragon'));
-    expect(screen.getByText('en'));
-    expect(screen.getByText('42h'));
+    const learningPathContainer = within(screen.getByTestId('learningPath'));
+    expect(learningPathContainer.getByText('How to train your dragon'));
+    expect(learningPathContainer.getByText('ENG'));
+    expect(learningPathContainer.getByText('42h'));
   });
 
   it('shows 2 cards in the course catalog', async () => {
@@ -237,10 +238,11 @@ describe('<Dashboard />', () => {
       },
     };
     renderWithRouter(<DashboardWithContext initialUserSubsidyState={userSubsidyState} />);
-    expect(screen.getByText('How to train your dragon'));
-    expect(screen.getByText('42h'));
-    expect(screen.getByText('Large numbers in Python'));
-    expect(screen.getByText('13h'));
-    expect((await screen.findAllByText('en')).length === 2);
+    const courseCatalogContainer = within(screen.getByTestId('courseCatalog'));
+    expect(courseCatalogContainer.getByText('How to train your dragon'));
+    expect(courseCatalogContainer.getByText('42h'));
+    expect(courseCatalogContainer.getByText('Large numbers in Python'));
+    expect(courseCatalogContainer.getByText('13h'));
+    expect((await courseCatalogContainer.findAllByText('ENG')).length === 2);
   });
 });

--- a/src/components/enterprise-user-subsidy/data/constants.js
+++ b/src/components/enterprise-user-subsidy/data/constants.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line import/prefer-default-export
 
+import { languageCodeToLabel } from '../../../utils/common';
+
 export const LOADING_SCREEN_READER_TEXT = 'loading your edX benefits from your organization';
 
 export const filterInitial = {
@@ -50,11 +52,11 @@ export const filterOptions = {
   languages: [
     {
       value: 'en',
-      label: 'EN',
+      label: languageCodeToLabel('en'),
     },
     {
       value: 'jp',
-      label: '日本',
+      label: languageCodeToLabel('jp'),
     },
   ],
   difficultyLevels: [

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -83,7 +83,7 @@ export const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
 export const languageCodeToLabel = (languageCode) => {
   switch (languageCode.toLowerCase()) {
     case 'en':
-      return 'ENG';
+      return 'English';
     case 'jp':
       return '日本';
     default:

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -79,3 +79,14 @@ export const delay = (delayDuration) => (
 );
 
 export const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
+
+export const languageCodeToLabel = (languageCode) => {
+  switch (languageCode.toLowerCase()) {
+    case 'en':
+      return 'ENG';
+    case 'jp':
+      return '日本';
+    default:
+      return languageCode.toUpperCase();
+  }
+};

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -83,7 +83,7 @@ export const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
 export const languageCodeToLabel = (languageCode) => {
   switch (languageCode.toLowerCase()) {
     case 'en':
-      return 'English';
+      return 'ENG';
     case 'jp':
       return '日本';
     default:

--- a/src/utils/common.test.js
+++ b/src/utils/common.test.js
@@ -6,6 +6,7 @@ import {
   hasTruthyValue,
   hasValidStartExpirationDates,
   fixedEncodeURIComponent,
+  languageCodeToLabel,
 } from './common';
 
 function assertTestCaseEquals(testCase, expectedValue) {
@@ -168,5 +169,14 @@ describe('hasValidStartExpirationDates', () => {
     };
     const result = hasValidStartExpirationDates(invalidExp);
     expect(result).toBeFalsy();
+  });
+});
+
+describe('languageCodeToLabel helper', () => {
+  it('properly translates known labels', () => {
+    expect(languageCodeToLabel('en')).toEqual('ENG');
+  });
+  it('returns the value, capitalized, when the code is unsupported', () => {
+    expect(languageCodeToLabel('pl')).toEqual('PL');
   });
 });

--- a/src/utils/common.test.js
+++ b/src/utils/common.test.js
@@ -174,7 +174,7 @@ describe('hasValidStartExpirationDates', () => {
 
 describe('languageCodeToLabel helper', () => {
   it('properly translates known labels', () => {
-    expect(languageCodeToLabel('en')).toEqual('ENG');
+    expect(languageCodeToLabel('en')).toEqual('English');
   });
   it('returns the value, capitalized, when the code is unsupported', () => {
     expect(languageCodeToLabel('pl')).toEqual('PL');

--- a/src/utils/common.test.js
+++ b/src/utils/common.test.js
@@ -174,7 +174,7 @@ describe('hasValidStartExpirationDates', () => {
 
 describe('languageCodeToLabel helper', () => {
   it('properly translates known labels', () => {
-    expect(languageCodeToLabel('en')).toEqual('English');
+    expect(languageCodeToLabel('en')).toEqual('ENG');
   });
   it('returns the value, capitalized, when the code is unsupported', () => {
     expect(languageCodeToLabel('pl')).toEqual('PL');


### PR DESCRIPTION
Added a utility function to help make sure we present the language names in unified way across the application:

![image](https://user-images.githubusercontent.com/90377295/188625701-ae11bdd0-025b-4098-8dc6-d0562638d1f4.png)
