### PR TITLE
[NO-STORY] bump moment from 2.29.1 to 2.29.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13948,9 +13948,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash.camelcase": "4.3.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
-    "moment": "2.29.1",
+    "moment": "2.29.4",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",


### PR DESCRIPTION
https://github.com/reustleco/dojo-frontend-app-learner-portal/security/dependabot/18
https://github.com/reustleco/dojo-frontend-app-learner-portal/security/dependabot/9

Bumps [moment](https://github.com/moment/moment) from 2.29.1 to 2.29.4.
- [Release notes](https://github.com/moment/moment/releases)
- [Changelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md)
- [Commits](https://github.com/moment/moment/compare/2.29.1...2.29.4)

---
updated-dependencies:
- dependency-name: moment dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>