### PR TITLE
[NO-STORY] bump axios from 0.21.1 to 0.21.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2099,6 +2099,14 @@
         "universal-cookie": "4.0.4"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
         "intl-messageformat": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
@@ -5427,11 +5435,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
+      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axios-cache-adapter": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@sentry/react": "^6.19.6",
     "@sentry/tracing": "^6.19.6",
     "algoliasearch": "4.6.0",
-    "axios": "0.21.1",
+    "axios": "0.21.2",
     "classnames": "2.2.6",
     "color": "3.1.3",
     "connected-react-router": "5.0.1",


### PR DESCRIPTION
https://github.com/reustleco/dojo-frontend-app-learner-portal/security/dependabot/8

Bumps [axios](https://github.com/axios/axios) from 0.21.1 to 0.21.2.
- [Release notes](https://github.com/axios/axios/releases)
- [Changelog](https://github.com/axios/axios/blob/master/CHANGELOG.md)
- [Commits](https://github.com/axios/axios/compare/v0.21.1...v0.21.2)

---
updated-dependencies:
- dependency-name: axios dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>