### PR TITLE
[NO-STORY] bump follow-redirects from 1.14.1 to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8969,9 +8969,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
     },
     "font-awesome": {
       "version": "4.7.0",


### PR DESCRIPTION
https://github.com/reustleco/dojo-frontend-app-learner-portal/security/dependabot/5
https://github.com/reustleco/dojo-frontend-app-learner-portal/security/dependabot/6

Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.14.1 to 1.15.0.
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.14.1...v1.15.0)

---
updated-dependencies:
- dependency-name: follow-redirects dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>
